### PR TITLE
Add pyvenv.cfg and bin/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+bin
+pyvenv.cfg
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
These files are created during virtualenv initialization and shouldn't be able to be checked into the repo. 