### PR TITLE
CU-x7ga5d: Fix SQLAlchemy queries

### DIFF
--- a/app/api/clock.py
+++ b/app/api/clock.py
@@ -462,9 +462,9 @@ def get_timecards():
         db.session.query(TimeCard, User.first_name, User.last_name)
         .join(User)
         .filter(
-            not TimeCard.paid,
-            not TimeCard.denied,
-            TimeCard.transaction_id is None,
+            TimeCard.paid == False,
+            TimeCard.denied == False,
+            TimeCard.transaction_id == None,
             User.manager_id == current_user.get_id(),
         )
         .all()
@@ -472,8 +472,10 @@ def get_timecards():
 
     # TODO: Implement paging here
     result = []
+    print(timecards)
     for i in timecards:
         timecard = i[0].to_dict()
+        print(f"Timecard: {timecard}")
         timecard["first_name"] = i[1]
         timecard["last_name"] = i[2]
         timecard["pay_rate"] = float(


### PR DESCRIPTION
SQLAlchemy Does not support things like `not my_attribute` or `foo is None`.
You must use comparison operators.

I'll need to go back and audit the code to make sure I didn't break any other filters, but if we need to fix dev for now this should do the trick. 